### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -9,9 +9,9 @@ class ItemsController < ApplicationController
     render 'new'
   end
 
-  #def show
-   # @item = Item.find(params[:id])
-  #end
+  def show
+    @item = Item.find(params[:id])
+  end
 
   def create
     @item = Item.new(item_params)

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -15,8 +15,4 @@ class Item < ApplicationRecord
                     numericality: { only_integer: true, greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999 },
                     format: { with: /\A[0-9]+\z/, message: 'は半角数字のみで入力してください' }
   validates :category_id, :status_id, :shipping_cost_id, :prefecture_id, :shipping_date_id, :image, presence: true
-
-  def sold_out?
-    sold == true
-  end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -17,6 +17,6 @@ class Item < ApplicationRecord
   validates :category_id, :status_id, :shipping_cost_id, :prefecture_id, :shipping_date_id, :image, presence: true
 
   def sold_out?
-    self.sold == true
+    sold == true
   end
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -130,7 +130,7 @@
     <% if @items.present? %>
       <% @items.each do |item| %>
         <li class='list'>
-          <%= link_to '#' do %>
+          <%= link_to item_path(item) do %>
             <div class='item-img-content'>
               <%= image_tag item.image.attached? ? url_for(item.image) :"item-sample.png", class: "item-img" %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -23,7 +23,7 @@
       </span>
     </div>
 
-    <% if user_signed_in? %>
+    <% if user_signed_in? && !@item.sold_out? %> 
     <% if @item.user == current_user %>
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
@@ -38,8 +38,6 @@
     <% end %>
     <% else %>
     <% end %>
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
       <span><%= @item.description %></span>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -23,21 +23,21 @@
       </span>
     </div>
 
-    <%# <% if user_signed_in? && !@item.sold_out? %> 
-    <%# <% if @item.user == current_user %>
+    <% if user_signed_in? %>
+    <% if @item.user == current_user %>
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
-    <%# <% else %>
+    <% else %>
 
-    <%# <% if @item.sold_out? %> 
-      <%# <p class="sold-out">Sold Out!</p> %>
-    <%# <% else %>     
+    <% if @item.sold_out? %> 
+      <p class="sold-out">Sold Out!</p>
+    <% else %>     
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# <% end %>
-    <%# <% end %>
-    <%# <% else %>
-    <%# <% end %>
+    <% end %>
+    <% end %>
+    <% else %>
+    <% end %>
 
     <div class="item-explain-box">
       <span><%= @item.description %></span>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -23,17 +23,21 @@
       </span>
     </div>
 
-    <%# しているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
+    <% if user_signed_in? %>
+    <% if @item.user == current_user %>
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+    <% else %>
 
-
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
+    <% if @item.sold_out? %>
+      <p class="sold-out">Sold Out!</p>
+    <% else %>    
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
-
+    <% end %>
+    <% end %>
+    <% else %>
+    <% end %>
 
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -30,8 +30,8 @@
     <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
     <% else %>
 
-    <% if @item.sold_out? %> 
-      <p class="sold-out">Sold Out!</p>
+    <%# <% if @item.sold_out? %>
+      <%# <p class="sold-out">Sold Out!</p> %>
     <% else %>     
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
     <% end %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -23,21 +23,21 @@
       </span>
     </div>
 
-    <% if user_signed_in? && !@item.sold_out? %> 
-    <% if @item.user == current_user %>
+    <%# <% if user_signed_in? && !@item.sold_out? %> 
+    <%# <% if @item.user == current_user %>
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
-    <% else %>
+    <%# <% else %>
 
-    <% if @item.sold_out? %>
-      <p class="sold-out">Sold Out!</p>
-    <% else %>    
+    <%# <% if @item.sold_out? %> 
+      <%# <p class="sold-out">Sold Out!</p> %>
+    <%# <% else %>     
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <% end %>
-    <% end %>
-    <% else %>
-    <% end %>
+    <%# <% end %>
+    <%# <% end %>
+    <%# <% else %>
+    <%# <% end %>
 
     <div class="item-explain-box">
       <span><%= @item.description %></span>
@@ -105,9 +105,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+  <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,22 +4,22 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.item_name %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
+      <%= image_tag @item.image.attached? ? url_for(@item.image) : "item-sample.png", class: "item-box-img" %>
+      <% if @item.sold_out? %>
       <div class="sold-out">
         <span>Sold Out!!</span>
       </div>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
+      <% end %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        ¥ <%= number_with_delimiter(@item.price, delimiter: ',') %>
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @item.shipping_cost.name %>
       </span>
     </div>
 
@@ -38,33 +38,33 @@
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.description %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.shipping_cost.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.shipping_date.name %></td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
What
商品詳細表示機能の実装

What
状況に応じて商品詳細ページの表示を変えることができるようにするため

ログイン状態且つ、自身が出品した販売中商品の商品詳細ページへ遷移した動画
https://gyazo.com/54667535802c8ace0b2b2ece4ee3b75a

ログイン状態且つ、自身が出品していない販売中商品の商品詳細ページへ遷移した動画
https://gyazo.com/1611106ce68fc35a406ec3b826773338

ログイン状態で、売却済み商品の商品詳細ページへ遷移した動画（現段階で商品購入機能の実装が済んでいる場合）
商品購入機能が済んでいないためありません


ログアウト状態で、商品詳細ページへ遷移した動画
https://gyazo.com/ab2a7805ddc55bbaea6019aad3773fb0