### PR TITLE
商品情報編集機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,7 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new, :create]
+  before_action :authenticate_user!, only: [:edit, :update]
   before_action :set_item, only: [:edit, :update]
+  before_action :redirect_if_sold_out, only: [:edit, :update]
 
   def index
     @items = Item.all.order(created_at: :desc)
@@ -18,13 +19,14 @@ class ItemsController < ApplicationController
   def edit
     @item = Item.find(params[:id])
     @categories = Category.all
-    @sales_statuses = Status.all # ここで@sales_statusesを正しく設定する
-    @shipping_fee_statuses = ShippingCost.all
+    @statuses = Status.all
+    @shipping_costs = ShippingCost.all
     @prefectures = Prefecture.all
-    @scheduled_deliveries = ShippingDate.all
+    @shipping_dates = ShippingDate.all
   end
 
   def update
+    @item = Item.find(params[:id])
     if @item.update(item_params)
       redirect_to @item
     else
@@ -49,6 +51,12 @@ class ItemsController < ApplicationController
 
   def set_item
     @item = Item.find(params[:id])
+  end
+
+  def redirect_if_sold_out
+    return unless @item.sold_out? || @item.user != current_user
+
+    redirect_to root_path
   end
 
   def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create]
+  before_action :set_item, only: [:edit, :update]
+
   def index
     @items = Item.all.order(created_at: :desc)
   end
@@ -44,6 +46,10 @@ class ItemsController < ApplicationController
   end
 
   private
+
+  def set_item
+    @item = Item.find(params[:id])
+  end
 
   def item_params
     params.require(:item).permit(:item_name, :category_id, :status_id, :description, :shipping_cost_id, :prefecture_id,

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:edit, :update]
   before_action :set_item, only: [:edit, :update]
   before_action :redirect_if_sold_out, only: [:edit, :update]
-  before_action :set_form_collections, only: [:edit, :update]
+  before_action :set_form_collections, only: [:show, :edit, :update]
   def index
     @items = Item.all.order(created_at: :desc)
   end
@@ -13,20 +13,15 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @item = Item.find(params[:id])
   end
 
   def edit
-    set_item
-    set_form_collections
   end
 
   def update
-    @item = Item.find(params[:id])
     if @item.update(item_params)
       redirect_to @item
     else
-      set_form_collections
       render :edit, status: :unprocessable_entity
     end
   end
@@ -59,7 +54,7 @@ class ItemsController < ApplicationController
   end
 
   def redirect_if_sold_out
-    return unless @item&.sold_out? || @item&.user != current_user
+    return unless @item.user != current_user
 
     redirect_to root_path
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -13,6 +13,23 @@ class ItemsController < ApplicationController
     @item = Item.find(params[:id])
   end
 
+  def edit
+    @item = Item.find(params[:id])
+    @categories = Category.all
+    @sales_statuses = Status.all # ここで@sales_statusesを正しく設定する
+    @shipping_fee_statuses = ShippingCost.all
+    @prefectures = Prefecture.all
+    @scheduled_deliveries = ShippingDate.all
+  end
+
+  def update
+    if @item.update(item_params)
+      redirect_to @item
+    else
+      render :edit
+    end
+  end
+
   def create
     @item = Item.new(item_params)
     @item.user = current_user

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,6 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:edit, :update]
   before_action :set_item, only: [:edit, :update]
   before_action :redirect_if_sold_out, only: [:edit, :update]
+  before_action :set_form_collections, only: [:edit, :update]
 
   def index
     @items = Item.all.order(created_at: :desc)
@@ -51,6 +52,14 @@ class ItemsController < ApplicationController
 
   def set_item
     @item = Item.find(params[:id])
+  end
+
+  def set_form_collections
+    @categories = Category.all
+    @statuses = Status.all
+    @shipping_costs = ShippingCost.all
+    @prefectures = Prefecture.all
+    @shipping_dates = ShippingDate.all
   end
 
   def redirect_if_sold_out

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -27,7 +27,7 @@ class ItemsController < ApplicationController
       redirect_to @item
     else
       set_form_collections
-      render :edit
+      render :edit, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,7 +3,6 @@ class ItemsController < ApplicationController
   before_action :set_item, only: [:edit, :update]
   before_action :redirect_if_sold_out, only: [:edit, :update]
   before_action :set_form_collections, only: [:edit, :update]
-
   def index
     @items = Item.all.order(created_at: :desc)
   end
@@ -18,12 +17,8 @@ class ItemsController < ApplicationController
   end
 
   def edit
-    @item = Item.find(params[:id])
-    @categories = Category.all
-    @statuses = Status.all
-    @shipping_costs = ShippingCost.all
-    @prefectures = Prefecture.all
-    @shipping_dates = ShippingDate.all
+    set_item
+    set_form_collections
   end
 
   def update
@@ -31,6 +26,7 @@ class ItemsController < ApplicationController
     if @item.update(item_params)
       redirect_to @item
     else
+      set_form_collections
       render :edit
     end
   end
@@ -63,7 +59,7 @@ class ItemsController < ApplicationController
   end
 
   def redirect_if_sold_out
-    return unless @item.sold_out? || @item.user != current_user
+    return unless @item&.sold_out? || @item&.user != current_user
 
     redirect_to root_path
   end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -18,5 +18,10 @@ class Item < ApplicationRecord
   validates :price, presence: true,
                     numericality: { only_integer: true, greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999 },
                     format: { with: /\A[0-9]+\z/, message: 'は半角数字のみで入力してください' }
-  validates :category_id, :status_id, :shipping_cost_id, :prefecture_id, :shipping_date_id, :image, presence: true
+  validates :category_id, numericality: { other_than: 1 }
+  validates :status_id, numericality: { other_than: 1 }
+  validates :shipping_cost_id, numericality: { other_than: 1 }
+  validates :prefecture_id, numericality: { other_than: 1 }
+  validates :shipping_date_id, numericality: { other_than: 1 }
+  validates :image, presence: true
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -2,6 +2,10 @@ class Item < ApplicationRecord
   belongs_to :user
   has_one_attached :image
 
+  def sold_out?
+    sold.present?
+  end
+
   extend ActiveHash::Associations::ActiveRecordExtensions
   belongs_to_active_hash :category
   belongs_to_active_hash :status

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,3 +1,6 @@
+<%= form_with(model: @item, local: true) do |f| %>
+
+
 <% if resource.errors.any? %>
   <div id="error_explanation" data-turbo-cache="false">
     <h2>

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,6 +1,3 @@
-<%= form_with(model: @item, local: true) do |f| %>
-
-
 <% if resource.errors.any? %>
   <div id="error_explanation" data-turbo-cache="false">
     <h2>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,11 +7,9 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with model: @item local: true do |f| %>
+    <%= form_with model: @item, local: true do |f| %>
 
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
     <%= render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
 
     <%# 商品画像 %>
     <div class="img-upload">
@@ -52,12 +50,12 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:category_id, [@categories], :id, :name, {prompt: '---'}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:category_id, @categories, :id, :name, {prompt: '---'}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:sales_status_id, [@sales_statuses], :id, :name, {prompt: '---'}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:sales_status_id, @sales_statuses, :id, :name, {prompt: '---'}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -73,17 +71,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:shipping_fee_status_id, [@shipping_fee_statuses], :id, :name, {prompt: '---'}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:shipping_fee_status_id, @shipping_fee_statuses, :id, :name, {prompt: '---'}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:prefecture_id, [@prefectures], :id, :name, {prompt: '---'}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:prefecture_id, @prefectures, :id, :name, {prompt: '---'}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:scheduled_delivery_id, [@scheduled_deliveries], :id, :name, {prompt: '---'}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:scheduled_delivery_id, @scheduled_deliveries, :id, :name, {prompt: '---'}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>
@@ -141,7 +139,7 @@ app/assets/stylesheets/items/new.css %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+      <%=link_to 'もどる', item_path(@item), class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -55,7 +55,7 @@ app/assets/stylesheets/items/new.css %>
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:sales_status_id, @sales_statuses, :id, :name, {prompt: '---'}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:status_id, @statuses, :id, :name, {prompt: '---'}, {class:"select-box", id:"item-status"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -71,7 +71,7 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:shipping_fee_status_id, @shipping_fee_statuses, :id, :name, {prompt: '---'}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:shipping_cost_id, @shipping_costs, :id, :name, {prompt: '---'}, {class:"select-box", id:"item-shipping-cost"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
@@ -81,7 +81,7 @@ app/assets/stylesheets/items/new.css %>
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:scheduled_delivery_id, @scheduled_deliveries, :id, :name, {prompt: '---'}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:shipping_date_id, @shipping_dates, :id, :name, {prompt: '---'}, {class:"select-box", id:"item-shipping-date"}) %>
       </div>
     </div>
     <%# /配送について %>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -53,7 +53,7 @@
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:status_id, Status.all, :id, :name, {prompt: '---'}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:status_id, Status.all, :id, :name, {prompt: '---'}, {class:"select-box", id:"item-status"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -69,7 +69,7 @@
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:shipping_cost_id, ShippingCost.all, :id, :name, {prompt: '---'}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:shipping_cost_id, ShippingCost.all, :id, :name, {prompt: '---'}, {class:"select-box", id:"item-shipping_cost"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
@@ -79,7 +79,7 @@
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:shipping_date_id, ShippingDate.all, :id, :name, {prompt: '---'}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:shipping_date_id, ShippingDate.all, :id, :name, {prompt: '---'}, {class:"select-box", id:"item-shipping-date"}) %>
       </div>
     </div>
     <%# /配送について %>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -137,7 +137,7 @@
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "出品する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', root_path, class:"back-btn" %>
+      <%=link_to 'もどる', item_path(@item), class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,7 +27,7 @@
     <% if @item.user == current_user %>
     <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
-    <%= link_to "削除", item_path(@item), data: {turbo_method: :delete}, class:"item-destroy" %>
+    <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
     <% else %>
           <%# <% unless @item.sold_out? %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -29,12 +29,11 @@
     <p class="or-text">or</p>
     <%= link_to "削除", item_path(@item), data: {turbo_method: :delete}, class:"item-destroy" %>
     <% else %>
-          <% unless @item.sold_out? %>
+          <%# <% unless @item.sold_out? %>
     <%= link_to "購入画面に進む", purchase_item_path(@item) ,class:"item-red-btn"%>
     <% end %>
     <% end %>
-    <% else %>
-    <% end %>
+    <%# <% end %> 
 
     <div class="item-explain-box">
       <span><%= @item.description %></span>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -8,11 +8,11 @@
     </h2>
     <div class="item-img-content">
       <%= image_tag @item.image.attached? ? url_for(@item.image) : "item-sample.png", class: "item-box-img" %>
-      <% if @item.sold_out? %>
+      <%# <% if @item.sold_out? %>
       <div class="sold-out">
         <span>Sold Out!!</span>
       </div>
-      <% end %>
+      <%# <% end %>
     </div>
     <div class="item-price-box">
       <span class="item-price">

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -25,15 +25,12 @@
 
     <% if user_signed_in? %>
     <% if @item.user == current_user %>
-    <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+    <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
-    <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+    <%= link_to "削除", item_path(@item), data: {turbo_method: :delete}, class:"item-destroy" %>
     <% else %>
-
-    <%# <% if @item.sold_out? %>
-      <%# <p class="sold-out">Sold Out!</p> %>
-    <% else %>     
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+          <% unless @item.sold_out? %>
+    <%= link_to "購入画面に進む", purchase_item_path(@item) ,class:"item-red-btn"%>
     <% end %>
     <% end %>
     <% else %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -30,7 +30,7 @@
     <%= link_to "削除", item_path(@item), data: {turbo_method: :delete}, class:"item-destroy" %>
     <% else %>
           <%# <% unless @item.sold_out? %>
-    <%= link_to "購入画面に進む", purchase_item_path(@item) ,class:"item-red-btn"%>
+    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
     <% end %>
     <% end %>
     <%# <% end %> 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,4 +3,8 @@ Rails.application.routes.draw do
   resources :users
   resources :items
   root to:"items#index"
+
+  resources :items do
+    get 'purchase', on: :member
+  end
 end


### PR DESCRIPTION
What
商品情報登録機能の実装

Why
誤ったデータが登録されると取引トラブルにつながるため

ログイン状態の出品者は、商品情報編集ページに遷移できる動画 
https://gyazo.com/182aee802670ab512fc10df9417cf83f  

必要な情報を適切に入力して「更新する」ボタンを押すと、商品の情報を編集できる動画 1️⃣https://gyazo.com/aa91abf295a0bdb55fcdfcf971f83587
2️⃣http://gyazo.com/cb86a2763ccc75fc9d619cd03d2de09a

 入力に問題がある状態で「変更する」ボタンが押された場合、情報は保存されず、編集ページに戻りエラーメッセージが表示される動画
https://gyazo.com/4ba954e6078e70aa4a1d2b4f63128a9b 

何も編集せずに「更新する」ボタンを押しても、画像無しの商品にならない動画 https://gyazo.com/b44c93f7c5b1f2408630f0fc63205ac7 

ログイン状態の場合でも、URLを直接入力して自身が出品していない商品の商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずトップページに遷移する動画 
https://gyazo.com/57a47fceda5ee8182be28fccdfcdb933

ログイン状態の場合でも、URLを直接入力して自身が出品した売却済み商品の商品情報編集ページへ遷移しようとすると、トップページに遷移する動画（現段階で商品購入機能の実装が済んでいる場合） 実装未なのでなし  

ログアウト状態の場合は、URLを直接入力して商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずログインページに遷移する動画 
https://gyazo.com/95fbb8b19c5efaea250813a6bd964d55

 商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される動画（商品画像・販売手数料・販売利益に関しては、表示されない状態で良い） 
https://gyazo.com/c8cdf934fa8df86712faa093669bc61a